### PR TITLE
adding spotless check to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2022.2.1"
+    id "com.diffplug.spotless" version "6.2.0"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11
@@ -85,3 +86,11 @@ jar {
 deployArtifact.jarTask = jar
 wpi.java.configureExecutableTasks(jar)
 wpi.java.configureTestTasks(test)
+
+apply plugin: 'com.diffplug.spotless'
+spotless {
+    java {
+        importOrder 'java', 'javax', 'org', 'com', ''
+        removeUnusedImports()
+    }
+}


### PR DESCRIPTION
This adds the `spotless` plugin to gradle from https://plugins.gradle.org/plugin/com.diffplug.spotless at Version 6.2.0 from 13 January 2022. 

"Spotless - keep your code spotless with Gradle"

Run in the terminal with

```
./gradlew :spotlessCheck
```